### PR TITLE
check that .ftpconfig path is not undefined

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -35,7 +35,7 @@ module.exports = {
 			self.treeView.root.name.attr('data-path', atom.project.remoteftp.root.remote);
 		});
 
-		if (hasProject()) {
+		if (hasProject() && atom.project.resolve('.ftpconfig')) {
 			FS.exists(atom.project.resolve('.ftpconfig'), function (exists) {
 				if (exists)
 					self.treeView.attach();


### PR DESCRIPTION
atom.project.resolve('.ftpconfig') can return undefined.
If an undefined object is handed over to FS.exists as an argument, there will be an error (TypeError: path must be a string) and the plugin won't be loaded at all.
