### PR TITLE
added option to get ssh-agent socket from environment var

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,8 +161,8 @@ module.exports = (function () {
 				if (self.info.agent)
 					info.agent = self.info.agent;
 
-				if (info.agent == 'env')                                                                                
-					info.agent = process.env.SSH_AUTH_SOCK   
+				if (self.info.agent == 'env')                                                                                
+					info.agent = process.env.SSH_AUTH_SOCK;
 
 				if (self.info.hosthash)
 					info.hostHash = self.info.hosthash;

--- a/lib/client.js
+++ b/lib/client.js
@@ -161,6 +161,9 @@ module.exports = (function () {
 				if (self.info.agent)
 					info.agent = self.info.agent;
 
+				if (info.agent == 'env')                                                                                
+					info.agent = process.env.SSH_AUTH_SOCK   
+
 				if (self.info.hosthash)
 					info.hostHash = self.info.hosthash;
 


### PR DESCRIPTION
When setting the "agent" option to "env" the plugin tries to get the socket for the ssh-agent from the environment variable SSH_AUTH_SOCK
