### PR TITLE
Fix indentation in remote-ftp.js.

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -49,7 +49,7 @@ module.exports = {
 
 				FS.writeFile(atom.project.resolve('.ftpconfig'), '{\n\
     "protocol": "ftp",\n\
-	"host": "example.com",\n\
+    "host": "example.com",\n\
     "port": 21,\n\
     "user": "user",\n\
     "pass": "pass",\n\
@@ -70,18 +70,18 @@ module.exports = {
 
 				FS.writeFile(atom.project.resolve('.ftpconfig'), '{\n\
     "protocol": "sftp",\n\
-	"host": "example.com",\n\
+    "host": "example.com",\n\
     "port": 22,\n\
     "user": "user",\n\
     "pass": "pass",\n\
     "remote": "/",\n\
-	"agent": "",\n\
+    "agent": "",\n\
     "privatekey": "",\n\
-	"passphrase": "",\n\
-	"hosthash": "",\n\
-	"ignorehost": true,\n\
-	"connTimeout": 10000,\n\
-	"keepalive": 10000\n\
+    "passphrase": "",\n\
+    "hosthash": "",\n\
+    "ignorehost": true,\n\
+    "connTimeout": 10000,\n\
+    "keepalive": 10000\n\
 }'			, function (err) {
 					if (!err)
 						atom.workspace.open(atom.project.resolve('.ftpconfig'));
@@ -91,117 +91,117 @@ module.exports = {
 			'remote-ftp:toggle': function () {
 				if (!hasProject()) return;
 
-	            self.treeView.toggle();
-	        },
+				self.treeView.toggle();
+			},
 
-	        'remote-ftp:connect': function () {
+			'remote-ftp:connect': function () {
 				if (!hasProject()) return;
 
-	            atom.project.remoteftp.readConfig(function (e) {
-	                if (e) {
+				atom.project.remoteftp.readConfig(function (e) {
+					if (e) {
 						throw "Could not read `.ftpconfig` file";
-	                    return;
-	                }
+						return;
+					}
 
 					if (!self.treeView.isVisible()) {
 						self.treeView.toggle();
 					}
 
-	                atom.project.remoteftp.connect();
-	            });
-	        },
+					atom.project.remoteftp.connect();
+				});
+			},
 
-	        'remote-ftp:disconnect': function () {
+			'remote-ftp:disconnect': function () {
 				if (!hasProject()) return;
 
-	            atom.project.remoteftp.disconnect();
-	        },
+				atom.project.remoteftp.disconnect();
+			},
 
-	        'remote-ftp:add-file': function () {
+			'remote-ftp:add-file': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            if (!AddDialog)
-	                AddDialog = require('./dialogs/add-dialog');
+				if (!AddDialog)
+					AddDialog = require('./dialogs/add-dialog');
 
-	            var dialog = new AddDialog('');
-	    		dialog.on('new-path', function (e, name) {
+				var dialog = new AddDialog('');
+				dialog.on('new-path', function (e, name) {
 					dialog.close();
 
-	                var remote = Path.join(remotes[0].item.remote, name).replace(/\\/g, '/');
+					var remote = Path.join(remotes[0].item.remote, name).replace(/\\/g, '/');
 
-	                atom.project.remoteftp.mkdir(remotes[0].item.remote, true, function (err) {
-	                    atom.project.remoteftp.mkfile(remote, function (err) {
+					atom.project.remoteftp.mkdir(remotes[0].item.remote, true, function (err) {
+						atom.project.remoteftp.mkfile(remote, function (err) {
 
-	                        remotes[0].open();
+							remotes[0].open();
 
-	                        if (!err)
-	                            atom.workspace.open(atom.project.remoteftp.toLocal(remote));
-	                    })
-	                });
-	    		});
-	            dialog.attach();
-	        },
+							if (!err)
+								atom.workspace.open(atom.project.remoteftp.toLocal(remote));
+						})
+					});
+				});
+				dialog.attach();
+			},
 
-	        'remote-ftp:add-folder': function () {
+			'remote-ftp:add-folder': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            if (!AddDialog)
-	                AddDialog = require('./dialogs/add-dialog');
+				if (!AddDialog)
+					AddDialog = require('./dialogs/add-dialog');
 
-	            var dialog = new AddDialog('');
-	            dialog.on('new-path', function (e, name) {
-	                var remote = Path.join(remotes[0].item.remote, name).replace(/\\/g, '/');
+				var dialog = new AddDialog('');
+				dialog.on('new-path', function (e, name) {
+					var remote = Path.join(remotes[0].item.remote, name).replace(/\\/g, '/');
 
-	                atom.project.remoteftp.mkdir(remote, true, function (err) {
-	                    dialog.close();
+					atom.project.remoteftp.mkdir(remote, true, function (err) {
+						dialog.close();
 
-	                    remotes[0].open();
-	                })
-	            });
-	            dialog.attach();
-	        },
+						remotes[0].open();
+					})
+				});
+				dialog.attach();
+			},
 
-	        'remote-ftp:refresh-selected': function () {
+			'remote-ftp:refresh-selected': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            remotes.forEach(function (remote) {
-	                remote.open();
-	            });
-	        },
+				remotes.forEach(function (remote) {
+					remote.open();
+				});
+			},
 
-	        'remote-ftp:move-selected': function () {
+			'remote-ftp:move-selected': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            if (!MoveDialog)
-	                MoveDialog = require('./dialogs/move-dialog');
+				if (!MoveDialog)
+					MoveDialog = require('./dialogs/move-dialog');
 
-	            var dialog = new MoveDialog(remotes[0].item.remote);
-	    		dialog.on('path-changed', function (e, newremote) {
-	    			atom.project.remoteftp.rename(remotes[0].item.remote, newremote, function (error) {
+				var dialog = new MoveDialog(remotes[0].item.remote);
+				dialog.on('path-changed', function (e, newremote) {
+					atom.project.remoteftp.rename(remotes[0].item.remote, newremote, function (error) {
 						dialog.close();
 
 						// Refresh new folder
@@ -214,27 +214,27 @@ module.exports = {
 						if (parentOld && parentOld != parentNew)
 							parentOld.open();
 
-	                    remotes[0].destroy();
-	    			});
-	    		});
-	    		dialog.attach();
-	        },
+						remotes[0].destroy();
+					});
+				});
+				dialog.attach();
+			},
 
-	        'remote-ftp:delete-selected': function () {
+			'remote-ftp:delete-selected': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            atom.confirm({
-	    			message: "Are you sure you want to delete the selected item?",
-	    			detailedMessage: "You are deleting:"+ remotes.map(function (view) { return "\n  " + view.item.remote; }),
-	                buttons: {
-	    				"Move to Trash": function () {
-	    					remotes.forEach(function (view) {
+				atom.confirm({
+					message: "Are you sure you want to delete the selected item?",
+					detailedMessage: "You are deleting:"+ remotes.map(function (view) { return "\n  " + view.item.remote; }),
+					buttons: {
+						"Move to Trash": function () {
+							remotes.forEach(function (view) {
 								if (!view) return;
 
 								var dir = Path.dirname(view.item.remote).replace(/\\/g, '/'),
@@ -245,42 +245,42 @@ module.exports = {
 										parent.open();
 									}
 								});
-	                         });
-	    				},
-	    				"Cancel": null
-	    			}
-	    		});
-	        },
+							 });
+						},
+						"Cancel": null
+					}
+				});
+			},
 
 			'remote-ftp:download-selected': function () {
 				if (!hasProject()) return;
 
-	            var remotes = self.treeView.getSelected();
+				var remotes = self.treeView.getSelected();
 				if (!remotes || remotes.length == 0) {
 					atom.notifications.addError("**Remote-FTP**<br />You need to select a folder first");
 					return;
 				}
 
-	            remotes.forEach(function (view) {
-	                if (!view) return;
+				remotes.forEach(function (view) {
+					if (!view) return;
 
-	                atom.project.remoteftp.download(view.item.remote, true, function (err) {
+					atom.project.remoteftp.download(view.item.remote, true, function (err) {
 
-	                })
-	            })
-	        },
+					})
+				})
+			},
 
 			'remote-ftp:upload-selected': function () {
 				if (!hasProject()) return;
 
 				var locals = $('.tree-view .selected').map(function () {
-				    return this.getPath ? this.getPath() : '';
+					return this.getPath ? this.getPath() : '';
 				}).get();
 
-	            locals.forEach(function (local) {
-	                if (!local) return;
+				locals.forEach(function (local) {
+					if (!local) return;
 
-	                atom.project.remoteftp.upload(local, function (err, list) {
+					atom.project.remoteftp.upload(local, function (err, list) {
 						if (err)
 							return;
 
@@ -298,16 +298,16 @@ module.exports = {
 							if (view)
 								view.open();
 						});
-	                });
-	            });
-	        },
+					});
+				});
+			},
 
 			// Remote -> local
 			'remote-ftp:sync-with-remote': function () {
 				var remotes = self.treeView.getSelected();
 
-	            remotes.forEach(function (view) {
-	                if (!view) return;
+				remotes.forEach(function (view) {
+					if (!view) return;
 
 					atom.project.remoteftp.syncRemoteLocal(view.item.remote, function (err) {
 
@@ -320,11 +320,11 @@ module.exports = {
 				if (!hasProject()) return;
 
 				var locals = $('.tree-view .selected').map(function () {
-				    return this.getPath ? this.getPath() : '';
+					return this.getPath ? this.getPath() : '';
 				}).get();
 
 				locals.forEach(function (local) {
-	                if (!local) return;
+					if (!local) return;
 
 					atom.project.remoteftp.syncLocalRemote(local, function (err) {
 						var remote = atom.project.remoteftp.toRemote(local);
@@ -350,15 +350,15 @@ module.exports = {
 				if (!hasProject()) return;
 
 				if (!AddDialog)
-	                AddDialog = require('./dialogs/navigate-to-dialog');
+					AddDialog = require('./dialogs/navigate-to-dialog');
 
-	            var dialog = new NavigateTo();
-	    		dialog.on('navigate-to', function (e, path) {
+				var dialog = new NavigateTo();
+				dialog.on('navigate-to', function (e, path) {
 					dialog.close();
 
 					atom.project.remoteftp.root.openPath(path);
-	    		});
-	            dialog.attach();
+				});
+				dialog.attach();
 			}
 		})
 


### PR DESCRIPTION
- Code indentation which is mixed tabs/spaces was fixed to use tabs like the rest of the code
- .ftpconfig template which is mixed tabs/spaces was fixed to use 4 spaces as that is the more common indentation within that file
