### PR TITLE
Ask for a filename instead of a directory name when creating a file

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -129,7 +129,7 @@ module.exports = {
 	            if (!AddDialog)
 	                AddDialog = require('./dialogs/add-dialog');
 
-	            var dialog = new AddDialog('');
+	            var dialog = new AddDialog('', true);
 	    		dialog.on('new-path', function (e, name) {
 					dialog.close();
 


### PR DESCRIPTION
When you create a file via the Remote-FTP context menu, the dialog says "Enter the path for the new **folder**".
The usage for the AddDialogs constructor is `new AddDialog (initialPath, isFile)`.
The true for `isFile` was missing.
