### PR TITLE
Added support for keyboard interactive SFTP login

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -176,6 +176,9 @@ module.exports = (function () {
 				if (self.info.ignorehost)
 					info.hostVerifier = function () { return true; }
 
+				if (self.info.keyboardInteractive)
+						info.tryKeyboard = true;
+
 				info.debug = function (str) {
 					/*var log = str.match(/^\[connection\] (>|<) '(.*?)(\\r\\n)?'$/);
 					if (!log) return;

--- a/lib/client.js
+++ b/lib/client.js
@@ -177,7 +177,7 @@ module.exports = (function () {
 					info.hostVerifier = function () { return true; }
 
 				if (self.info.keyboardInteractive)
-						info.tryKeyboard = true;
+					info.tryKeyboard = true;
 
 				info.debug = function (str) {
 					/*var log = str.match(/^\[connection\] (>|<) '(.*?)(\\r\\n)?'$/);

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -72,6 +72,9 @@ module.exports = (function () {
 			if (typeof debug == 'function')
 				debug.apply(null, [str]);
 		});
+		self.ssh2.on('keyboard-interactive', function (name, instructions, instructionsLang, prompts, finish) {
+			finish([self.info.password]);
+		});
 		self.ssh2.connect(self.info);
 
 		return self;

--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -81,7 +81,8 @@ module.exports = {
     "hosthash": "",\n\
     "ignorehost": true,\n\
     "connTimeout": 10000,\n\
-    "keepalive": 10000\n\
+    "keepalive": 10000,\n\
+	"keyboardInteractive": false\n\
 }'			, function (err) {
 					if (!err)
 						atom.workspace.open(atom.project.resolve('.ftpconfig'));

--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -82,7 +82,7 @@ module.exports = {
     "ignorehost": true,\n\
     "connTimeout": 10000,\n\
     "keepalive": 10000,\n\
-	"keyboardInteractive": false\n\
+    "keyboardInteractive": false\n\
 }'			, function (err) {
 					if (!err)
 						atom.workspace.open(atom.project.resolve('.ftpconfig'));


### PR DESCRIPTION
Some SSH servers are configured to require keyboard interactive login by default.
This patch will allow remote-ftp to connect to MacOSX hosts.

The "keyboardInteractive" key in the .ftpconfig file (for SFTP only) indicate to ssh2 to try keyboard-interactive login if the previous authentication methods failed.
