### PR TITLE
add tree-view class to fix styling

### DIFF
--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -32,7 +32,7 @@ module.exports = TreeView = (function (parent) {
 				'outlet': 'scroller'
 			}, function () {
 				this.ol({
-					'class': 'full-menu list-tree has-collapsable-children focusable-panel',
+					'class': 'tree-view full-menu list-tree has-collapsable-children focusable-panel',
 					'tabindex': -1,
 					'outlet': 'list'
 				});


### PR DESCRIPTION
This fixes the main folder styling. May want to add a thin line to the left to separate the folder views.
Before
![before](https://cloud.githubusercontent.com/assets/5185561/8142394/f37ce95e-1140-11e5-918a-005b53bc5f47.png)
After
![after](https://cloud.githubusercontent.com/assets/5185561/8142396/f6b88056-1140-11e5-8aad-1f8ecb044101.png)
