### PR TITLE
Better error handling on invalid JSON in .ftpconfig

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -75,8 +75,8 @@ module.exports = (function () {
 			try {
 				json = JSON.parse(data);
 			} catch (err) {
-				throw "Parse error in `.ftpconfig` JSON : " + err;
-				//return e('Parse error in .ftpconfg\'s JSON :\n  '+ err);
+				atom.notifications.addError('Could not parse `.ftpconfig`', { detail: 'Please check your `.ftpconfig` for invalid JSON syntax. It has to contain valid JSON to be parsed properly!' });
+				return;
 			}
 
 			self.info = json;


### PR DESCRIPTION
Don't show an 'Create issue' button for this error.
The user has to correct his .ftpconfig himself.

This way people (hopefully) stop creating issues like #156 #68 #133 #145 #142 
