### PR TITLE
Added validation module to show errors more precisely

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,8 @@ var __hasProp = {}.hasOwnProperty,
 	events = require('events'),
 	FTP,
 	SFTP,
-	Directory = require('./directory');
+	Directory = require('./directory'),
+	LintStream = require('jslint').LintStream;
 
 module.exports = (function () {
 
@@ -72,20 +73,49 @@ module.exports = (function () {
 				return e(err);
 
 			var json;
-			try {
+			
+			if( self.validateConfig( data ) ) {
 				json = JSON.parse(data);
-			} catch (err) {
-				atom.notifications.addError('Could not parse `.ftpconfig`', { detail: 'Please check your `.ftpconfig` for invalid JSON syntax. It has to contain valid JSON to be parsed properly!' });
-				return;
+
+				self.info = json;
+				self.root.name = '';
+				self.root.path = '/' + self.info.remote.replace(/^\/+/, '');
+
+				if (typeof callback === 'function')
+					callback.apply(self, [err, json]);
 			}
-
-			self.info = json;
-			self.root.name = '';
-			self.root.path = '/' + self.info.remote.replace(/^\/+/, '');
-
-			if (typeof callback === 'function')
-				callback.apply(self, [err, json]);
 		});
+	}
+	
+	Client.prototype.validateConfig = function( data ) {
+		var valid = true;
+		
+		var lintStream = new LintStream( { edition: "latest" } );
+		lintStream.write( { file: '.ftpconfig', body: data } );
+		lintStream.on( 'data', function( chunk ) {
+			var error = chunk.linted.errors.slice( 0, 1 );
+			if( error.length ) {
+				error = error[0];
+				atom.notifications.addError('Could not parse `.ftpconfig`', { detail: error.message + "\n" + chunk.linted.lines[ error.line ] });
+				
+				atom.workspace.open( '.ftpconfig' ).then( function( editor ) {
+					var decorationConfig = { class:'ftpconfig_line_error' };
+					editor.getDecorations( decorationConfig ).forEach( function( decoration ) {
+						decoration.destroy();
+					})
+					
+					var range = editor.getBuffer().clipRange( [ [ error.line, 0 ], [ error.line, Infinity ] ] );
+					var marker = editor.markBufferRange( range, { invalidate: 'inside' } );
+					
+					decorationConfig.type = 'line';
+					editor.decorateMarker( marker, decorationConfig );
+				});
+
+				valid = false;
+			}
+		});
+		
+		return valid;
 	}
 
 	Client.prototype.isConnected = function (onconnect) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ssh2": "*",
     "fs-plus": "*",
     "theorist": "*",
-    "atom-space-pen-views": "^2.0.3"
+    "atom-space-pen-views": "^2.0.3",
+    "jslint": "*"
   }
 }

--- a/styles/ftpconfig_errors.atom-text-editor.less
+++ b/styles/ftpconfig_errors.atom-text-editor.less
@@ -1,0 +1,4 @@
+.ftpconfig_line_error
+{
+	background: rgba(255, 0, 0, 0.5) !important;
+}


### PR DESCRIPTION
Feature  #175

Before parsing `.ftpconfig` it contents is checked. If any error is found, `.ftpconfig` will be opened and first error marked.

![capture](https://cloud.githubusercontent.com/assets/9192409/9265937/bc441252-423a-11e5-9070-e1754f883e45.PNG)
