### PR TITLE
Showing symbolic links as file in order to edit and view them

### DIFF
--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -135,11 +135,11 @@ module.exports = (function () {
 							item.date.setTime(item.attrs.mtime * 1000);
 							list.push({
 								name: item.filename,
-								type: item.attrs.isFile() ? 'f' : 'd',
+								type: (item.attrs.isFile() || item.attrs.isSymbolicLink()) ? 'f' : 'd',
 								size: item.attrs.size,
 								date: item.date
 							});
-							if (!item.attrs.isFile()) {
+							if (!(item.attrs.isFile() || item.attrs.isSymbolicLink())) {
 								l(item.filename);
 							}
 						});
@@ -161,7 +161,7 @@ module.exports = (function () {
 							item.date.setTime(item.attrs.mtime * 1000);
 							list.push({
 								name: item.filename,
-								type: item.attrs.isFile() ? 'f' : 'd',
+								type: (item.attrs.isFile() || item.attrs.isSymbolicLink()) ? 'f' : 'd',
 								size: item.attrs.size,
 								date: item.date
 							});
@@ -192,8 +192,8 @@ module.exports = (function () {
 						completed.apply(null, [err]);
 					return;
 				}
-
-				if (stats.isFile()) {
+				
+				if (stats.isFile() || stats.isSymbolicLink()) {
 					// File
 					FS.makeTreeSync(Path.dirname(local));
 					self.sftp.fastGet(path, local, {
@@ -463,7 +463,7 @@ module.exports = (function () {
 					return;
 				}
 
-				if (stats.isFile()) {
+				if (stats.isFile() || stats.isSymbolicLink()) {
 					// File
 					self.sftp.unlink(path, function (err) {
 						if (typeof completed === 'function')


### PR DESCRIPTION
Showing symbolic links as file in order to edit and view them. Fixing
Issue  "Symlinks shown as directories #238"
