### PR TITLE
chore(Dependencies): Fix ssh2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "ftp": "*",
-    "ssh2": "*",
+    "ssh2": "^0.4",
     "fs-plus": "*",
     "theorist": "*",
     "atom-space-pen-views": "^2.0.3",


### PR DESCRIPTION
Actually some ssh hosts might not work with sha1 or md5 as `hosthash`, so ssh2 only handled it as none in =< 0.4.14 versions.

---
### Related issues
- #321 
- #324 
- #326
