### PR TITLE
Added support for keyboard arrows navigation inside remote treeview

### DIFF
--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -187,6 +187,7 @@ module.exports = TreeView = (function (parent) {
 		self.horizontalResize.on('dblclick', function (e) { self.resizeToFitContent(e); });
 		self.horizontalResize.on('mousedown', function (e) { self.resizeHorizontalStarted(e); });
 		self.verticalResize.on('mousedown', function (e) { self.resizeVerticalStarted(e); });
+		self.list.on('keydown', function (e) { self.remoteKeyboardNavigation(e); });
 
 		atom.project.remoteftp.on('connected', function () {
 			self.showOnline();
@@ -317,6 +318,99 @@ module.exports = TreeView = (function (parent) {
 
 		this.width(1);
 		this.width(this.list.outerWidth());
+	};
+
+	TreeView.prototype.remoteKeyboardNavigation = function (e) {
+		var arrows = {left: 37, up: 38, right: 39, down: 40 },
+			keyCode = e.keyCode || e.which;
+
+		if (!keyCode in arrows) return;
+
+		e.preventDefault();
+		e.stopPropagation();
+		switch (keyCode) {
+			case arrows.up:
+				this.remoteKeyboardNavigationUp();
+				break;
+			case arrows.down:
+				this.remoteKeyboardNavigationDown();
+				break;
+			case arrows.left:
+				this.remoteKeyboardNavigationLeft();
+				break;
+			case arrows.right:
+				this.remoteKeyboardNavigationRight();
+				break;
+		}
+		this.remoteKeyboardNavigationMovePage();
+	};
+
+	TreeView.prototype.remoteKeyboardNavigationUp = function () {
+		var current = this.list.find('.selected'),
+			next = current.prev('.entry:visible');
+		if (next.length) {
+			while (next.is('.expanded') && next.find('.entries .entry:visible').length) {
+				next = next.find('.entries .entry:visible');
+			}
+		} else {
+			next = current.closest('.entries').closest('.entry:visible');
+		}
+		if (next.length) {
+			current.removeClass('selected');
+			next.last().addClass('selected');
+		}
+	};
+
+	TreeView.prototype.remoteKeyboardNavigationDown = function () {
+		var current = this.list.find('.selected'),
+			next = current.find('.entries .entry:visible');
+		if (!next.length) {
+			tmp = current;
+			do {
+				next = tmp.next('.entry:visible');
+				if (!next.length) {
+					tmp = tmp.closest('.entries').closest('.entry:visible');
+				}
+			} while (!next.length && !tmp.is('.project-root'));
+		}
+		if (next.length) {
+			current.removeClass('selected');
+			next.first().addClass('selected');
+		}
+	};
+
+	TreeView.prototype.remoteKeyboardNavigationLeft = function () {
+		var current = this.list.find('.selected');
+		if (!current.is('.directory')) {
+			next = current.closest('.directory');
+			next.view().collapse();
+			current.removeClass('selected');
+			next.first().addClass('selected');
+		} else {
+			current.view().collapse();
+		}
+	};
+
+	TreeView.prototype.remoteKeyboardNavigationRight = function () {
+		var current = this.list.find('.selected');
+		if (current.is('.directory')) {
+			var view = current.view();
+			view.open();
+			view.expand();
+		}
+	};
+
+	TreeView.prototype.remoteKeyboardNavigationMovePage = function () {
+		var current = this.list.find('.selected');
+		if (current.length) {
+			var scrollerTop = this.scroller.scrollTop(),
+				selectedTop = current.position().top;
+			if (selectedTop < scrollerTop - 10) {
+				this.scroller.pageUp();
+			} else if (selectedTop > scrollerTop + this.scroller.height() - 10) {
+				this.scroller.pageDown();
+			}
+		}
 	};
 
 	return TreeView;

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -324,10 +324,6 @@ module.exports = TreeView = (function (parent) {
 		var arrows = {left: 37, up: 38, right: 39, down: 40 },
 			keyCode = e.keyCode || e.which;
 
-		if (!keyCode in arrows) return;
-
-		e.preventDefault();
-		e.stopPropagation();
 		switch (keyCode) {
 			case arrows.up:
 				this.remoteKeyboardNavigationUp();
@@ -341,7 +337,12 @@ module.exports = TreeView = (function (parent) {
 			case arrows.right:
 				this.remoteKeyboardNavigationRight();
 				break;
+			default:
+				return;
 		}
+
+		e.preventDefault();
+		e.stopPropagation();
 		this.remoteKeyboardNavigationMovePage();
 	};
 


### PR DESCRIPTION
The difference in behavior of keyboard arrows navigation inside remote treeview before and after this commit displayed below.

![modification](https://cloud.githubusercontent.com/assets/950216/13995607/ec6ead8e-f13a-11e5-91b0-edf9d1b9b691.jpg)
