### PR TITLE
[Feature] On project path change, disconnect from the old .ftpconfig

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -389,6 +389,15 @@ module.exports = {
 			var listener = buffer.onDidSave(self.fileSaved.bind(self));
 			self.listeners.push(listener);
 		});
+		
+		self.listeners.push(atom.project.onDidChangePaths(function() {
+			if(!hasProject() && !atom.project.remoteftp.isConnected()) {
+				return;
+			}
+
+			atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:disconnect');
+			atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:connect');
+		}));
 	},
 
 	deactivate: function () {

--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -391,7 +391,7 @@ module.exports = {
 		});
 		
 		self.listeners.push(atom.project.onDidChangePaths(function() {
-			if(!hasProject() && !atom.project.remoteftp.isConnected()) {
+			if(!hasProject() || !atom.project.remoteftp.isConnected()) {
 				return;
 			}
 


### PR DESCRIPTION
When the project path changes, disconnect from the old project and connect using the new path. Only happens when Atom has a project and Remote-FTP is connected.

Works really well when using the plugin project-viewer (https://github.com/jccguimaraes/atom-project-viewer) is used to switch the atom project path.

Might need to implement a better version that handles having multiple paths in a project. I believe remote-ftp only connects to the first path in the list.
