### PR TITLE
Allows watch directory

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -745,10 +745,10 @@ module.exports = (function() {
 			watchData.forEach(function(watch) {
 				var fileName = Path.resolve(dir, watch);
 				FS.stat(fileName, function(err, stats) {
-					if (err === null && stats.isFile()) {
+					if (err === null && (stats.isFile() || stats.isDirectory())) {
 						var originalFileName = Path.basename(fileName);
 						var watcher = FS.watch(fileName, function(event, file) {
-
+              console.log(event, file);
 							var directory = Path.dirname(fileName);
 							if (event === "rename") {
 								atom.notifications.addError("Remote FTP: The file " + originalFileName + " has either been deleted or renamed, removing watch listener on this file.");

--- a/lib/client.js
+++ b/lib/client.js
@@ -748,7 +748,6 @@ module.exports = (function() {
 					if (err === null && (stats.isFile() || stats.isDirectory())) {
 						var originalFileName = Path.basename(fileName);
 						var watcher = FS.watch(fileName, function(event, file) {
-              console.log(event, file);
 							var directory = Path.dirname(fileName);
 							if (event === "rename") {
 								atom.notifications.addError("Remote FTP: The file " + originalFileName + " has either been deleted or renamed, removing watch listener on this file.");


### PR DESCRIPTION
Updated `FS.stat` test to allow `isDirectory` as well as `isFile`. This allows the user to add a directory to the `watch` option in `.ftpconfig`. This is helpful when a task outputs various files (for example jsdoc will output a lot of files with possibly unknown names).
