### PR TITLE
Add copy-name feature

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -22,6 +22,10 @@ module.exports = {
 		showViewOnStartup: {
 			type: 'boolean',
 			'default': true
+		},
+		enableCopyFilename: {
+			type: 'boolean',
+			'default': true
 		}
 	},
 
@@ -58,6 +62,21 @@ module.exports = {
 					self.treeView.attach();
 				}
 			});
+		}
+
+		var copyname_context = {
+			'.remote-ftp-view .entries.list-tree:not(.multi-select) .directory .header': [
+				{ label: 'Copy name', command: 'remote-ftp:copy-name' },
+				{ type: 'separator' }
+			],
+			'.remote-ftp-view .entries.list-tree:not(.multi-select) .file': [
+				{ label: 'Copy filename', command: 'remote-ftp:copy-name' },
+				{ type: 'separator' }
+			]
+		};
+
+		if (atom.config.get('Remote-FTP.enableCopyFilename')) {
+		    atom.contextMenu.add(copyname_context);
 		}
 
 		atom.commands.add('atom-workspace', {
@@ -384,6 +403,19 @@ module.exports = {
 					atom.project.remoteftp.root.openPath(path);
 				});
 				dialog.attach();
+			},
+
+			'remote-ftp:copy-name': function(){
+				if (!hasProject()) return;
+
+				var remotes = self.treeView.getSelected();
+				if (!remotes || remotes.length === 0) { return; }
+
+				var name = remotes.map(function(data) {
+				    return data.item.name;
+				}) + '';
+
+				atom.clipboard.write(name);
 			}
 		});
 

--- a/lib/views/directory-view.js
+++ b/lib/views/directory-view.js
@@ -73,8 +73,12 @@ module.exports = DirectoryView = (function (parent) {
 					break;
 
 				default:
-					if (!e.ctrlKey)
+					if (!e.ctrlKey) {
 						$('.remote-ftp-view .selected').removeClass('selected');
+						$('.remote-ftp-view .entries.list-tree').removeClass('multi-select');
+					} else {
+						$('.remote-ftp-view .entries.list-tree').addClass('multi-select');
+					}
 					view.toggleClass('selected');
 
 					if (button === 0) {

--- a/lib/views/file-view.js
+++ b/lib/views/file-view.js
@@ -57,8 +57,12 @@ module.exports = FileView = (function (parent) {
 						return;
 
 				default:
-					if (!e.ctrlKey)
+					if (!e.ctrlKey) {
 						$('.remote-ftp-view .selected').removeClass('selected');
+						$('.remote-ftp-view .entries.list-tree').removeClass('multi-select');
+					} else {
+						$('.remote-ftp-view .entries.list-tree').addClass('multi-select');
+					}
 					view.toggleClass('selected');
 			}
 		});


### PR DESCRIPTION
This pull included: 
- Add Multi-select support in context-menu
- Add Copy filename / name in context-menu
- Added option in Remote-FTP Settings page
