### PR TITLE
Amends to SFTP connector & watch functionality

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -782,7 +782,7 @@ module.exports = (function() {
 					for (var i = 0; i < self.watch.files.length; i++) {
 						var file = self.watch.files[i];
 						if (file != fileName) continue;
-						var listener = self.watch.listeners.splice(i, 1);
+						var listener = self.watch.listeners.splice(i, 1)[0];
 						listener.close();
 						self.watch.listenerCount--;
 						self.watch.files.splice(i, 1);

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,7 +19,8 @@ var __hasProp = {}.hasOwnProperty,
 	FTP,
 	SFTP,
 	Directory = require('./directory'),
-	LintStream = require('jslint').LintStream;
+	LintStream = require('jslint').LintStream,
+	chokidar = require("chokidar");
 
 module.exports = (function() {
 
@@ -437,7 +438,6 @@ module.exports = (function() {
 
 	Client.prototype.upload = function(local, callback) {
 		var self = this;
-
 		//if (self.isConnected()) {
 		self.onceConnected(function() {
 			self._enqueue(function(progress) {
@@ -707,6 +707,7 @@ module.exports = (function() {
 
 
 	Client.prototype.watch = {
+		watcher:null,
 		listenerCount: 0,
 		files: [],
 		listeners: [],
@@ -721,88 +722,41 @@ module.exports = (function() {
 			}
 			if (!Array.isArray(watchData) || watchData.length < 1) return;
 
-			function listenerLoop(i, len) {
-				if (i != len - 1) return;
-
-				// let user know all watchers have started
-				if (self.watch.listenerCount === 0) {
-					// only gets called if all files in self.info.watch cannot be found
-					atom.notifications.addInfo("Remote FTP: No files being watched");
-				} else {
-					atom.notifications.addInfo("Remote FTP: " + self.watch.listenerCount + " file(s) being watched.");
-				}
-
-				self.watch.addingListeners = false;
-				self.emit("added-watch-listeners");
-			}
-
-			self.watch.addingListeners = true;
-
 			var dir = atom.project.getDirectories()[0].getRealPathSync();
-			var i = 0;
-			var len = watchData.length;
 
-			watchData.forEach(function(watch) {
-				var fileName = Path.resolve(dir, watch);
-				FS.stat(fileName, function(err, stats) {
-					if (err === null && stats.isFile()) {
-						var originalFileName = Path.basename(fileName);
-						var watcher = FS.watch(fileName, function(event, file) {
-
-							var directory = Path.dirname(fileName);
-							if (event === "rename") {
-								atom.notifications.addError("Remote FTP: The file " + originalFileName + " has either been deleted or renamed, removing watch listener on this file.");
-								self.watch.removeListeners.apply(self, [fileName]);
-							}
-
-							self.watch.queueUpload.apply(self, [directory + "/" + file]);
-						});
-
-						self.watch.listeners.push(watcher);
-						self.watch.files.push(fileName);
-						self.watch.listenerCount++;
-						listenerLoop(i, len);
-						i++;
-					} else { // let user know that could not find file
-						atom.notifications.addError("Remote FTP: Could not find " + fileName + " to watch.");
-						listenerLoop(i, len);
-						i++;
-					}
-				});
-
+			var watchDataFormatted = watchData.map(function(watch){
+				return Path.resolve(dir, watch);
 			});
+
+
+			var watcher = chokidar.watch(watchDataFormatted, {
+		  ignored: /[\/\\]\./,
+		  persistent: true
+			});
+
+			watcher
+			.on("change", function(path, stats){
+				var directory = Path.dirname(path);
+				self.watch.queueUpload.apply(self, [path]);
+			})
+			// .on("unlink", function(path) {
+			// 	atom.notifications.addError("Remote FTP: The file " + path + " has either been deleted or renamed, removing watch listener on this file.");
+			// 	watcher.unwatch(path);
+			// });
+
+			atom.notifications.addInfo("Remote FTP: Added watch listeners");
+			self.watcher = watcher;
+			self.watch.addingListeners = false;
+			self.emit("added-watch-listeners");
 
 		},
 		removeListeners: function(fileName) {
 			var self = this;
 
 			function remove() {
-				if (fileName) {
-
-					for (var i = 0; i < self.watch.files.length; i++) {
-						var file = self.watch.files[i];
-						if (file != fileName) continue;
-						var listener = self.watch.listeners.splice(i, 1)[0];
-						listener.close();
-						self.watch.listenerCount--;
-						self.watch.files.splice(i, 1);
-					}
-
-				} else {
-
-					self.watch.listeners.forEach(function(listener) {
-						listener.close();
-					});
-
-					var count = self.watch.listenerCount;
-
-					self.watch.files = [];
-					self.watch.listenerCount = 0;
-					self.watch.listeners = [];
-
-					if (count !== 0) {
-						atom.notifications.addInfo("Remote FTP: Stopped watching " + count + " file(s)");
-					}
+				if(self.watcher != null){
+					self.watcher.close();
+					atom.notifications.addInfo("Remote FTP: Stopped watch listeners");
 				}
 			}
 

--- a/lib/connectors/ftp.js
+++ b/lib/connectors/ftp.js
@@ -40,7 +40,9 @@ module.exports = (function () {
 			self.emit('ended');
 		});
 		self.ftp.on('error', function (err) {
+			//console.log("ERROR HERE", err);
 			self.emit('error', err);
+			self.disconnect();
 		});
 		self.info._debug = self.info.debug;
 		self.info.debug = function (str) {

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -290,82 +290,112 @@ module.exports = (function () {
 		var self = this,
 			remote = self.client.toRemote(path);
 
+
+			function put(obj) {
+				// Possibly deconstruct in coffee script? If thats a thing??
+				var localPath = obj.localPath;
+				var remotePath = obj.remotePath;
+				var e = obj.e;
+				var i = obj.i;
+				var total = obj.total;
+
+
+				var readStream = FS.createReadStream( localPath );
+				var writeStream = self.sftp.createWriteStream( remotePath );
+				var fileSize = FS.statSync( localPath ).size; // used for setting progress bar
+				var totalRead = 0; // used for setting progress bar
+
+
+				function applyProgress() {
+					if(total != null && i != null){
+						progress.apply(null, [(i / total) + (totalRead / fileSize / total)]);
+					}
+					else{
+						progress.apply(null, [totalRead / fileSize]);
+					}
+				}
+
+
+				writeStream
+				.on("finish", function() {
+					applyProgress(); // completes the progress bar
+					return e();
+				})
+				.on("error", function(err) {
+					console.log("writestream error");
+					return e(err);
+	      });
+
+				readStream
+				.on("data", function(chunk) {
+					totalRead += chunk.length;
+					if(totalRead === fileSize) return; // let writeStream.on("finish") complete the progress bar
+					applyProgress();
+				});
+
+				readStream.pipe( writeStream );
+
+			}
+
 		if (self.isConnected()) {
+
 			// File
 			if (FS.isFileSync(path)) {
 				var e = function (err) {
 					if (typeof completed === 'function')
 						completed.apply(null, [err ? err : null, [{name: path, type: 'f'}]]);
 				};
-				self.sftp.fastPut(path, remote, {
-					step: function (written, chunk, size) {
-						if (typeof progress === 'function')
-							progress.apply(null, [written / size]);
-					}
-				}, function (err) {
-					if (err) {
-						if (err.type == 'NO_SUCH_FILE' || err.message == 'No such file') {
-							self.mkdir(Path.dirname(remote).replace(/\\/g, '/'), true, function (err) {
-								if (err)
-									return e(err);
 
-								self.sftp.fastPut(path, remote, {
-									step: function (written, chunk, size) {
-										if (typeof progress === 'function')
-											progress.apply(null, [written / size]);
-									}
-								}, function (err) {
-									return e(err);
-								});
-							});
-							return;
-						}
-						return e(err);
-					}
-
-					return e();
+				put({
+					localPath:path,
+					remotePath:remote,
+					e:e
 				});
 
 			}
 
 			// Folder
-			else {
-				self.client._traverseTree(path, function (list) {
-					self.mkdir(remote, true, function (err) {
-						var error,
-							i = -1,
-							total = list.length;
-						var e = function () {
-							if (typeof completed === 'function')
-								completed.apply(null, [error, list]);
-						};
-						var n = function () {
-							if (++i >= list.length)
-								return e();
-							var item = list[i],
-								remote = self.client.toRemote(item.name);
-							if (item.type == 'd' || item.type == 'l') {
-								self.sftp.mkdir(remote, {}, function (err) {
-									if (err)
-										error = err;
-									return n();
-								});
-							} else {
-								self.sftp.fastPut(item.name, remote, {
-									step: function (written, chunk, size) {
-										if (typeof progress === 'function')
-											progress.apply(null, [(i / total) + (written / size / total)]);
-									}
-								}, function (err) {
-									if (err)
-										error = err;
-									return n();
-								});
-							}
-						};
-						return n();
+			else{
+					self.client._traverseTree(path, function (list) {
+						self.mkdir(remote, true, function (err) {
+							var error,
+								i = -1,
+								total = list.length;
+							var e = function () {
+								if (typeof completed === 'function')
+									completed.apply(null, [error, list]);
+							};
+							var n = function () {
+								if (++i >= list.length)
+									return e();
+								var item = list[i],
+									remote = self.client.toRemote(item.name);
+								if (item.type == 'd' || item.type == 'l') {
+									self.sftp.mkdir(remote, {}, function (err) {
+										if (err)
+											error = err;
+										return n();
+									});
+								} else {
+
+									put({
+										localPath:item.name,
+										remotePath:remote,
+										i:i,
+										total:total,
+										e:function(err) {
+											if(err){
+												error = err;
+												return n();
+											}
+										}
+									});
+
+								}
+							};
+							return n();
+						});
 					});
-				});
 			}
 		}
 		else {

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -322,8 +322,17 @@ module.exports = (function () {
 					return e();
 				})
 				.on("error", function(err) {
-					atom.notifications.addError("Remote FTP: Writestream Error" + err);
-					return e(err);
+					//atom.notifications.addError("Remote FTP: Writestream Error" + err);
+
+					// if(err === "NO_SUCH_FILE" || err === "No such file"){
+					//
+					// 	self.mkdir(Path.dirname(remote).replace(/\\/g, '/'), true, function (err) {
+					// 			if (err) atom.notifications.addError("Remote FTP:" + err); return err;
+					// 			put(obj);
+					// 	});
+					// 
+					// }
+					//return e(err);
 	      });
 
 				readStream

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -322,17 +322,22 @@ module.exports = (function () {
 					return e();
 				})
 				.on("error", function(err) {
-					//atom.notifications.addError("Remote FTP: Writestream Error" + err);
+					if( !obj.hasOwnProperty("err") && (err.message == "No such file" || err.message === "NO_SUCH_FILE")){
 
-					// if(err === "NO_SUCH_FILE" || err === "No such file"){
-					//
-					// 	self.mkdir(Path.dirname(remote).replace(/\\/g, '/'), true, function (err) {
-					// 			if (err) atom.notifications.addError("Remote FTP:" + err); return err;
-					// 			put(obj);
-					// 	});
-					// 
-					// }
-					//return e(err);
+							self.mkdir(Path.dirname(remote).replace(/\\/g, '/'), true, function (err) {
+										if (err){
+											var error = err.message || err;
+											atom.notifications.addError("Remote FTP: Upload Error" + error);
+											return err;
+										}
+										put(Object.assign({}, obj, {err:err}));
+								});
+					}
+					else{
+						var error = err.message || err;
+						atom.notifications.addError("Remote FTP: Upload Error" + error);
+					}
+
 	      });
 
 				readStream

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -322,7 +322,7 @@ module.exports = (function () {
 					return e();
 				})
 				.on("error", function(err) {
-					console.log("writestream error");
+					atom.notifications.addError("Remote FTP: Writestream Error" + err);
 					return e(err);
 	      });
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "atom": ">=0.204.0 <2.0.0"
   },
   "dependencies": {
-    "ftp": "*",
-    "ssh2": "^0.4",
-    "fs-plus": "*",
-    "theorist": "*",
     "atom-space-pen-views": "^2.0.3",
+    "chokidar": "^1.6.0",
+    "fs-plus": "*",
+    "ftp": "*",
     "jslint": "*",
-    "strip-json-comments": "*"
+    "ssh2": "^0.4",
+    "strip-json-comments": "*",
+    "theorist": "*"
   }
 }


### PR DESCRIPTION
Amended the sftp connector to use streams for uploading instead of the `fastPut` method from ssh2, which in my testing has shown no truncating on uploading what so ever.

Changed how the watch functionality is implemented. Now using `chokidar`, which firstly removes the issue were the watch handler would be removed ( when it shouldn't be ) this would display the error message `Remote FTP: 'something.css' has either been deleted or renamed, removing watch listener on this file`. Secondly it allows globs and directories to be watched.

Fixes issues:
- #330 
- #378 
