### PR TITLE
Added right click selection support

### DIFF
--- a/lib/views/directory-view.js
+++ b/lib/views/directory-view.js
@@ -66,30 +66,22 @@ module.exports = DirectoryView = (function (parent) {
 			if (!view)
 				return;
 
-			switch (button) {
-				case 2:
-					if (view.is('.selected'))
-						return;
-					break;
+			if (button === 0 || button == 2) {
+				if (!e.ctrlKey) {
+					$('.remote-ftp-view .selected').removeClass('selected');
+					$('.remote-ftp-view .entries.list-tree').removeClass('multi-select');
+				} else {
+					$('.remote-ftp-view .entries.list-tree').addClass('multi-select');
+				}
+				view.toggleClass('selected');
 
-				default:
-					if (!e.ctrlKey) {
-						$('.remote-ftp-view .selected').removeClass('selected');
-						$('.remote-ftp-view .entries.list-tree').removeClass('multi-select');
-					} else {
-						$('.remote-ftp-view .entries.list-tree').addClass('multi-select');
-					}
-					view.toggleClass('selected');
+				if (view.item.status === 0)
+					view.open();
 
-					if (button === 0) {
-						if (view.item.status === 0)
-							view.open();
-
-						if (button === 0)
-							view.toggle();
-						else
-							view.expand();
-					}
+				if (button === 0)
+					view.toggle();
+				else
+					view.expand();
 			}
 		});
 		self.on('dblclick', function (e) {

--- a/lib/views/directory-view.js
+++ b/lib/views/directory-view.js
@@ -80,8 +80,6 @@ module.exports = DirectoryView = (function (parent) {
 
 				if (button === 0)
 					view.toggle();
-				else
-					view.expand();
 			}
 		});
 		self.on('dblclick', function (e) {


### PR DESCRIPTION
Items in the tree view can now be selected via right click as well as
left click. This means users can now right click on a folder and add a
file directly to it without having to first select it with a left click.
