### PR TITLE
Added ability to download fresh copies of local files

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -93,6 +93,7 @@ module.exports = {
 					"pass": "pass",
 					"promptForPass": false,
 					"remote": "/",
+					"local": "",
 					"secure": false,
 					"secureOptions": null,
 					"connTimeout": 10000,
@@ -117,6 +118,7 @@ module.exports = {
 					"pass": "pass",
 					"promptForPass": false,
 					"remote": "/",
+					"local": "",
 					"agent": "",
 					"privatekey": "",
 					"passphrase": "",
@@ -332,6 +334,36 @@ module.exports = {
 
 					});
 				});
+			},
+
+			'remote-ftp:download-selected-local': function () {
+				if (!hasProject()) return;
+				if ( atom.project.remoteftp.root.local == "" ) {
+					atom.notifications.addError("**Remote-FTP**<br />You must define your local root folder in the project's .ftpconfig file.");
+					return;
+				}
+
+				if ( !atom.project.remoteftp.isConnected() ) {
+					// just connect
+					atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:connect');
+
+					atom.project.remoteftp.on('connected', function () {
+						atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:download-selected-local');
+					});
+					return;
+				}
+
+				var locals = $('.tree-view .selected').map(function () {
+					var path = this.getPath ? this.getPath() : '';
+					var localPath = path.replace(atom.project.remoteftp.root.local,"");
+					// if this is windows, the path may have \ instead of / as directory separators
+					var remotePath = atom.project.remoteftp.root.remote + localPath.replace( /\\/g, "/" );
+					atom.project.remoteftp.download(remotePath, true, function (err) {
+
+					});
+				});
+
+				return;
 			},
 
 			'remote-ftp:upload-selected': function () {

--- a/menus/remote-ftp.cson
+++ b/menus/remote-ftp.cson
@@ -17,7 +17,8 @@
       { label: 'Rename', command: 'remote-ftp:move-selected' },
       { label: 'Delete', command: 'remote-ftp:delete-selected' },
       { label: 'Download', command: 'remote-ftp:download-selected' },
-      { label: 'Sync local <- remote', command: 'remote-ftp:sync-with-remote' }
+      { label: 'Sync local <- remote', command: 'remote-ftp:sync-with-remote' },
+      { label: 'Hide', command: 'remote-ftp:toggle' }
     ]
   '.remote-ftp-view .list-tree.multi-select': [
       { label: 'Download', command: 'remote-ftp:download-selected' },

--- a/menus/remote-ftp.cson
+++ b/menus/remote-ftp.cson
@@ -2,10 +2,12 @@
 'context-menu':
   '.tree-view.full-menu': [
       { label: 'Upload', command: 'remote-ftp:upload-selected' },
+      { label: 'Download', command: 'remote-ftp:download-selected-local' },
       { label: 'Sync local -> remote', command: 'remote-ftp:sync-with-local' }
     ]
   '.tree-view.multi-select': [
       { label: 'Upload', command: 'remote-ftp:upload-selected' },
+      { label: 'Download', command: 'remote-ftp:download-selected-local' },
       { label: 'Sync local -> remote', command: 'remote-ftp:sync-with-local' }
     ]
   '.remote-ftp-view .list-tree.full-menu': [


### PR DESCRIPTION
While browsing the local tree view, user can now select local files, right click, and click a new "Download" option which downloads a fresh copy of the file from the remote location. FTP connection is created if necessary.
