### PR TITLE
only loads if a .ftpconfig is detected in the project

### DIFF
--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -1,8 +1,27 @@
 var FS, Path, $, Client, TreeView, Ignore, AddDialog, MoveDialog, NavigateTo, multipleHostsEnabled;
 
+var path = require('path')
+var fs = require('fs')
+
 function hasProject() {
 	return atom.project && atom.project.getPaths().length;
 }
+
+function shouldLoad() {
+	var paths = atom.project.getPaths();
+	var projPath = paths[0];
+	var ftpconfig = path.format({
+		dir: project,
+		base: '.ftpconfig'
+	});
+
+	try fs.accessSync(ftpconfig);
+	catch (err) return false;
+
+	return true;
+};
+
+var willLoad = shouldLoad()
 
 module.exports = {
 	config: {
@@ -37,7 +56,7 @@ module.exports = {
 	client: null,
 	listeners: [],
 
-	activate: function (state) {
+	activate: !willLoad ? function(){} : function (state) {
 		var self = this;
 
 		if (!FS) {
@@ -476,7 +495,7 @@ module.exports = {
 		}));
 	},
 
-	deactivate: function () {
+	deactivate: !willLoad ? function(){} : function () {
 		var self = this;
 
 		self.listeners.forEach(function (l) {
@@ -488,7 +507,7 @@ module.exports = {
 			atom.project.remoteftp.disconnect();
 	},
 
-	fileSaved: function (text) {
+	fileSaved: !willLoad ? function(){} : function (text) {
 		if (!hasProject()) return;
 
 		if (atom.config.get('Remote-FTP.autoUploadOnSave') == 'never') return;


### PR DESCRIPTION
My PR adds a `shouldLoad` function and only binds to activates/deactivates/fileSaved if there’s a .ftpconfig file in the base directory of the project
