### PR TITLE
Update toLocal function to use POSIX compatible path

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -386,7 +386,7 @@ export default (function INIT() {
     toLocal(remote) {
       const self = this;
       if (multipleHostsEnabled() === true) { // if multiple hosts is checked
-        return `${self.projectPath}\\${remote.substr(self.info.remote.length).replace(/^\/+/, '')}`;
+        return `${self.projectPath}/${remote.substr(self.info.remote.length).replace(/^\/+/, '')}`;
       }
 
       return atom.project.getDirectories()[0].resolve(`./${remote.substr(self.info.remote.length).replace(/^\/+/, '')}`);


### PR DESCRIPTION
Fixes issue #503 . On OS X the path separator used in the toLocal function of client.js is causing issues on download. Pretty sure this fix will work on Windows since it supports both forward and back slashes.