### PR TITLE
Transfer Notifications

### DIFF
--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -23,5 +23,9 @@
   "multipleHosts ( Beta )":{
     "type":"boolean",
     "default":false
+  },
+  "enableTransferNotifications":{
+    "type":"boolean",
+    "default":false
   }
 }

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -141,11 +141,20 @@ const init = function INIT() {
             return;
           }
 
+          var hideFTPTreeView = false;
           if (!remoteftp.treeView.isVisible()) {
             remoteftp.treeView.toggle();
+            hideFTPTreeView = true;
           }
 
           client.connect();
+
+          if ( hideFTPTreeView ) {
+              atom.project.remoteftp.once('connected', () => {
+                remoteftp.treeView.toggle();
+              });
+          }
+
         });
       },
     },

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -312,14 +312,47 @@ const init = function INIT() {
           return;
         }
 
+        if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+    		// TODO: correctly count files within a subdirectory
+    		var requestedTransfers = 0;
+    		var successfulTransfers = 0;
+    		var attemptedTransfers = 0;
+
+    		$('.tree-view .selected').map(function () {
+    			requestedTransfers++;
+    		});
+        }
+
         $('.tree-view .selected').each(function MAP() {
           const path = this.getPath ? this.getPath() : '';
           const localPath = path.replace(atom.project.remoteftp.root.local, '');
           // if this is windows, the path may have \ instead of / as directory separators
           const remotePath = atom.project.remoteftp.root.remote + localPath.replace(/\\/g, '/');
           atom.project.remoteftp.download(remotePath, true, () => {
+            if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+                attemptedTransfers++;
+                if ( !err ) {
+                    successfulTransfers++;
+                }
+            }
           });
         });
+
+        if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+            var waitingForTransfers = setInterval( function(){
+                if ( attemptedTransfers == requestedTransfers ) {
+                    // we're done waiting
+                    clearInterval( waitingForTransfers );
+                    if ( successfulTransfers == requestedTransfers ) {
+                        // great, all uploads worked
+                        atom.notifications.addSuccess("Remote FTP: All transfers succeeded (" + successfulTransfers + " of " + requestedTransfers + ").");
+                    } else {
+                        // :( some uploads failed
+                        atom.notifications.addError("Remote FTP: Some transfers failed<br />There were " + successfulTransfers + " successful out of an expected " + requestedTransfers + ".");
+                    }
+                }
+            }, 200 );
+        }
 
         return;
       },
@@ -336,11 +369,18 @@ const init = function INIT() {
 
         const filteredLocals = remoteftp.omitIgnored(locals);
 
+        if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+            var successfulTransfers = 0;
+            var attemptedTransfers = 0;
+        }
+
         filteredLocals.forEach((local) => {
           if (!local) return;
 
           client.upload(local, (err, list) => {
+            if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) { attemptedTransfers++; }
             if (err) return;
+            if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) { successfulTransfers++; }
 
             const dirs = [];
             list.forEach((item) => {
@@ -355,6 +395,22 @@ const init = function INIT() {
             });
           });
         });
+
+        if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+            var waitingForTransfers = setInterval( function(){
+                if ( attemptedTransfers == filteredLocals.length) {
+                    // we're done waiting
+                    clearInterval( waitingForTransfers );
+                    if ( successfulTransfers == filteredLocals.length ) {
+                        // great, all uploads worked
+                        atom.notifications.addSuccess("Remote FTP: All transfers succeeded (" + successfulTransfers + " of " + filteredLocals.length + ").");
+                    } else {
+                        // :( some uploads failed
+                        atom.notifications.addError("Remote FTP: Some transfers failed<br />There were " + successfulTransfers + " successful out of an expected " + filteredLocals.length + ".");
+                    }
+                }
+            }, 200 );
+        }
       },
     },
     // Remote -> Local

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -330,10 +330,9 @@ const init = function INIT() {
           const remotePath = atom.project.remoteftp.root.remote + localPath.replace(/\\/g, '/');
           atom.project.remoteftp.download(remotePath, true, () => {
             if ( atom.config.get('Remote-FTP.enableTransferNotifications') ) {
+                // TODO: check if any errors were thrown, indicating an unsuccessful transfer
                 attemptedTransfers++;
-                if ( !err ) {
-                    successfulTransfers++;
-                }
+                successfulTransfers++;
             }
           });
         });
@@ -361,6 +360,17 @@ const init = function INIT() {
       enabled: true,
       command() {
         if (!hasProject()) return;
+
+        if (!client.isConnected()) {
+          // just connect
+          atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:connect');
+
+          atom.project.remoteftp.once('connected', () => {
+            atom.commands.dispatch(atom.views.getView(atom.workspace), 'remote-ftp:upload-selected');
+          });
+
+          return;
+        }
 
         const locals = $('.tree-view .selected').map(function MAP() {
           return this.getPath ? this.getPath() : '';


### PR DESCRIPTION
Adds optional Atom notification upon completion of transfers

I like seeing a notification when transfers are finished, so I added it on the "upload" and "download-selected-local" functions. Off by default so it shouldn't impact existing users unless they turn it on.