### PR TITLE
ftp.js Readability

### DIFF
--- a/lib/connectors/ftp.js
+++ b/lib/connectors/ftp.js
@@ -11,6 +11,12 @@ const atom = global.atom;
 //
 // }
 
+function tryApply(callback, context, args){
+  if (typeof callback === 'function') {
+    callback.apply(context, args);
+  }
+}
+
 export default (function INIT() {
   class ConnectorFTP extends Connector {
     constructor(...args) {
@@ -37,7 +43,7 @@ export default (function INIT() {
       })
       .on('ready', () => {
         self.emit('connected');
-        if (typeof completed === 'function') completed.apply(self, []);
+        tryApply(completed, self, []);
       })
       .on('end', () => {
         self.emit('ended');
@@ -64,7 +70,7 @@ export default (function INIT() {
         const reply = log[2].match(/^[0-9]+/);
         if (reply) self.emit(reply[0], log[2]);
 
-        if (typeof self.info._debug === 'function') self.info._debug.apply(null, [str]);
+        tryApply(self.info._debug, null, [str]);
       };
       self.ftp.connect(self.info);
 
@@ -78,7 +84,7 @@ export default (function INIT() {
         self.ftp.destroy();
         self.ftp = null;
       }
-      if (typeof completed === 'function') completed.apply(null, []);
+      tryApply(completed, null, []);
       return self;
     }
 
@@ -87,9 +93,9 @@ export default (function INIT() {
 
       if (self.isConnected()) {
         self.ftp.abort(() => {
-          if (typeof completed === 'function') completed.apply(null, []);
+          tryApply(completed, null, []);
         });
-      } else if (typeof completed === 'function') completed.apply(null, []);
+      } else tryApply(completed, null, []);
       return self;
     }
 
@@ -112,9 +118,7 @@ export default (function INIT() {
           let digg = 0;
 
           const error = () => {
-            if (typeof completed === 'function') {
-              completed.apply(null, [null, list]);
-            }
+            tryApply(completed, null, [null, list])
           };
           const l = function (p) {
             ++digg;
@@ -155,12 +159,10 @@ export default (function INIT() {
                 }
               });
             }
-            if (typeof completed === 'function') {
-              completed.apply(null, [err, list]);
-            }
+            tryApply(completed, null, [err, list]);
           });
         }
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
 
       return self;
     }
@@ -185,25 +187,25 @@ export default (function INIT() {
                   pool = setInterval(() => {
                     if (!self.ftp || !self.ftp._pasvSocket) return;
                     const read = self.ftp._pasvSocket.bytesRead;
-                    if (typeof progress === 'function') progress.apply(null, [read / size]);
+                    tryApply(progress, null, [read / size]);
                   }, 250);
                 }
               });
               self.ftp.get(path, (error, stream) => {
                 if (error) {
                   if (pool) clearInterval(pool);
-                  if (typeof completed === 'function') completed.apply(null, [err]);
+                  tryApply(completed, null, [err]);
                   return;
                 }
 
                 const dest = FS.createWriteStream(local);
                 dest.on('unpipe', () => {
                   if (pool) clearInterval(pool);
-                  if (typeof completed === 'function') completed.apply(null, []);
+                  tryApply(completed, null, []);
                 });
                 dest.on('error', (destError) => {
                   if (pool) clearInterval(pool);
-                  if (typeof completed === 'function') completed.apply(null, [destError]);
+                  tryApply(completed, null, [destError]);
                 });
                 stream.pipe(dest);
               });
@@ -223,12 +225,12 @@ export default (function INIT() {
                 let pool;
                 const total = list.length;
                 const e = () => {
-                  if (typeof completed === 'function') completed.apply(null, [error, list]);
+                  tryApply(completed, null, [error, list]);
                 };
                 const n = () => {
                   ++i;
                   if (pool) clearInterval(pool);
-                  if (typeof progress === 'function') progress.apply(null, [i / total]);
+                  tryApply(progress, null, [i / total]);
 
                   const item = list.shift();
                   if (typeof item === 'undefined' || item === null) return e();
@@ -246,7 +248,7 @@ export default (function INIT() {
                         pool = setInterval(() => {
                           if (!self.ftp || !self.ftp._pasvSocket) return;
                           read = self.ftp._pasvSocket.bytesRead;
-                          if (typeof progress === 'function') progress.apply(null, [(i / total) + (read / size / total)]);
+                          tryApply(progress, null, [(i / total) + (read / size / total)]);
                         }, 250);
                       }
                     });
@@ -267,7 +269,7 @@ export default (function INIT() {
             }
           });
         });
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
       return self;
     }
 
@@ -283,12 +285,12 @@ export default (function INIT() {
           let written = 0;
 
           const e = (err) => {
-            if (typeof completed === 'function')completed.apply(null, [err ? err : null, [{ name: path, type: 'f' }]]);
+            tryApply(completed, null, [err ? err : null, [{ name: path, type: 'f' }]]);
           };
           const pool = setInterval(() => {
             if (!self.ftp || !self.ftp._pasvSocket) return;
             written = self.ftp._pasvSocket.bytesWritten;
-            if (typeof progress === 'function') progress.apply(null, [written / size]);
+            tryApply(progress, null, [written / size]);
           }, 250);
 
           self.ftp.put(path, remote, (err) => {
@@ -317,11 +319,11 @@ export default (function INIT() {
               const pool = setInterval(() => {
                 if (!self.ftp || !self.ftp._pasvSocket) return;
                 written = self.ftp._pasvSocket.bytesWritten;
-                if (typeof progress === 'function') progress.apply(null, [(i / total) + (written / size / total)]);
+                tryApply(progress, null, [(i / total) + (written / size / total)]);
               }, 250);
               const e = function () {
                 if (pool) clearInterval(pool);
-                if (typeof completed === 'function') completed.apply(null, [error, list]);
+                tryApply(completed, null, [error, list]);
               };
               const n = function () {
                 if (++i >= list.length) return e();
@@ -346,7 +348,7 @@ export default (function INIT() {
             });
           });
         }
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
 
       return self;
     }
@@ -369,14 +371,14 @@ export default (function INIT() {
 
           self.ftp.mkdir(dir, (err) => {
             if (last) {
-              if (typeof completed === 'function') completed.apply(null, [err ? err : null]);
+              tryApply(completed, null, [err ? err : null]);
             } else {
               return n();
             }
           });
         };
         n();
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
 
       return self;
     }
@@ -389,16 +391,16 @@ export default (function INIT() {
       if (self.isConnected()) {
         self.ftp.put(empty, path, (err) => {
           if (err) {
-            if (typeof completed === 'function') completed.apply(null, [err]);
+            tryApply(completed, null, [err]);
             return;
           }
 
           FS.makeTreeSync(Path.dirname(local));
           FS.writeFile(local, empty, (err2) => {
-            if (typeof completed === 'function') completed.apply(null, [err2]);
+            tryApply(completed, null, [err2]);
           });
         });
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
 
       return self;
     }
@@ -409,15 +411,15 @@ export default (function INIT() {
       if (self.isConnected()) {
         self.ftp.rename(source, dest, (err) => {
           if (err) {
-            if (typeof completed === 'function') completed.apply(null, [err]);
+            tryApply(completed, null, [err]);
           } else {
             FS.rename(self.client.toLocal(source), self.client.toLocal(dest), (err) => {
-              if (typeof completed === 'function') completed.apply(null, [err]);
+              tryApply(completed, null, [err]);
             });
           }
         });
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
-
+      } else tryApply(completed, null, ['Not connected']);
+      
       return self;
     }
 
@@ -430,7 +432,7 @@ export default (function INIT() {
             if (err) {
               // NOTE: File
               self.ftp.delete(path, (err) => {
-                if (typeof completed === 'function') completed.apply(null, [err, [{ name: path, type: 'f' }]]);
+                tryApply(completed, null, [err, [{ name: path, type: 'f' }]]);
               });
             } else {
               // NOTE: Folder
@@ -445,7 +447,7 @@ export default (function INIT() {
 
                 const e = function () {
                   self.ftp.rmdir(path, (err) => {
-                    if (typeof completed === 'function') completed.apply(null, [err, list]);
+                    tryApply(completed, null, [err, list]);
                   });
                 };
                 list.forEach((item) => {
@@ -460,7 +462,7 @@ export default (function INIT() {
             }
           });
         });
-      } else if (typeof completed === 'function') completed.apply(null, ['Not connected']);
+      } else tryApply(completed, null, ['Not connected']);
 
       return self;
     }


### PR DESCRIPTION
Just a modest PR to make ftp.js more readable. Should eventually apply similar changes to sftp.js but I believe that's in the process of being changed to make use of es2015 syntax with babel, like what's been done to ftp.js . If something like this is being done I think it might be a good idea to get rid of all the semicolons (As a part of the es2015 syntax enhancements)