### PR TITLE
Add support for File-Icons v2.0

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,3 +23,12 @@ export const getObject = function GETOBJECT({ keys, obj }) {
 export const hasProject = function HASPROJECT() {
   return atom.project && atom.project.getPaths().length;
 };
+
+let addIconToElement;
+export const setIconHandler = function SETICONHANDLER(fn) {
+  addIconToElement = fn;
+};
+
+export const getIconHandler = function GETICONHANDLER(){
+  return addIconToElement;
+};

--- a/lib/remote-ftp.js
+++ b/lib/remote-ftp.js
@@ -7,9 +7,11 @@ import Client from './client';
 import TreeView from './views/tree-view';
 import {
   hasProject,
+  setIconHandler,
 } from './helpers';
 import initCommands from './menus/main';
 
+import {Disposable} from 'atom';
 const atom = global.atom;
 const config = require('./config-schema.json');
 
@@ -116,6 +118,13 @@ class Main {
       .filter(locals);
 
     return filteredLocals;
+  }
+
+  consumeElementIcons(fn) {
+    setIconHandler(fn);
+    return new Disposable(() => {
+      setIconHandler(null);
+    });
   }
 
 }

--- a/lib/views/directory-view.js
+++ b/lib/views/directory-view.js
@@ -2,6 +2,7 @@ var __hasProp = {}.hasOwnProperty,
 	__extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
 	$ = require('atom-space-pen-views').$,
 	FileView = require('./file-view'),
+	getIconHandler = require('../helpers.js').getIconHandler,
 	View = require('atom-space-pen-views').View;
 
 module.exports = DirectoryView = (function (parent) {
@@ -41,7 +42,12 @@ module.exports = DirectoryView = (function (parent) {
 		self.name.text(self.item.name);
 		self.name.attr('data-name', self.item.name);
 		self.name.attr('data-path', self.item.remote);
-		self.name.addClass(self.item.type && self.item.type == 'l' ? 'icon-file-symlink-directory' : 'icon-file-directory');
+		
+		var addIconToElement = getIconHandler();
+		if(addIconToElement)
+			this.iconDisposable = addIconToElement(self.item, self.item.remote);
+		else
+			self.name.addClass(self.item.type && self.item.type == 'l' ? 'icon-file-symlink-directory' : 'icon-file-directory');
 
 		if (self.item.isExpanded || self.item.isRoot)
 			self.expand();
@@ -98,6 +104,11 @@ module.exports = DirectoryView = (function (parent) {
 
 	DirectoryView.prototype.destroy = function () {
 		this.item = null;
+
+		if(this.iconDisposable){
+			this.iconDisposable.dispose();
+			this.iconDisposable = null;
+		}
 
 		this.remove();
 	};

--- a/lib/views/directory-view.js
+++ b/lib/views/directory-view.js
@@ -44,8 +44,11 @@ module.exports = DirectoryView = (function (parent) {
 		self.name.attr('data-path', self.item.remote);
 		
 		var addIconToElement = getIconHandler();
-		if(addIconToElement)
-			this.iconDisposable = addIconToElement(self.item, self.item.remote);
+		if(addIconToElement){
+			const element = self.name[0] || self.name;
+			const path = self.item && self.item.local;
+			this.iconDisposable = addIconToElement(element, path, {isDirectory: true});
+		}
 		else
 			self.name.addClass(self.item.type && self.item.type == 'l' ? 'icon-file-symlink-directory' : 'icon-file-directory');
 

--- a/lib/views/file-view.js
+++ b/lib/views/file-view.js
@@ -1,6 +1,7 @@
 var __hasProp = {}.hasOwnProperty,
 	__extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
 	$ = require('atom-space-pen-views').$,
+	getIconHandler = require('../helpers.js').getIconHandler,
 	View = require('atom-space-pen-views').View;
 
 module.exports = FileView = (function (parent) {
@@ -32,14 +33,18 @@ module.exports = FileView = (function (parent) {
 		self.name.attr('data-name', self.item.name);
 		self.name.attr('data-path', self.item.remote);
 
-		switch (self.item.type) {
-			case 'binary':		self.name.addClass('icon-file-binary'); break;
-			case 'compressed':	self.name.addClass('icon-file-zip'); break;
-			case 'image':		self.name.addClass('icon-file-media'); break;
-			case 'pdf':			self.name.addClass('icon-file-pdf'); break;
-			case 'readme':		self.name.addClass('icon-book'); break;
-			case 'text':		self.name.addClass('icon-file-text'); break;
-		}
+		var addIconToElement = getIconHandler();
+		if(addIconToElement)
+			this.iconDisposable = addIconToElement(self.item, self.item.remote);
+		else
+			switch (self.item.type) {
+				case 'binary':		self.name.addClass('icon-file-binary'); break;
+				case 'compressed':	self.name.addClass('icon-file-zip'); break;
+				case 'image':		self.name.addClass('icon-file-media'); break;
+				case 'pdf':			self.name.addClass('icon-file-pdf'); break;
+				case 'readme':		self.name.addClass('icon-book'); break;
+				case 'text':		self.name.addClass('icon-file-text'); break;
+			}
 
 		// Events
 		self.on('mousedown', function (e) {
@@ -77,6 +82,11 @@ module.exports = FileView = (function (parent) {
 
 	FileView.prototype.destroy = function () {
 		this.item = null;
+		
+		if(this.iconDisposable){
+			this.iconDisposable.dispose();
+			this.iconDisposable = null;
+		}
 
 		this.remove();
 	};

--- a/lib/views/file-view.js
+++ b/lib/views/file-view.js
@@ -34,8 +34,11 @@ module.exports = FileView = (function (parent) {
 		self.name.attr('data-path', self.item.remote);
 
 		var addIconToElement = getIconHandler();
-		if(addIconToElement)
-			this.iconDisposable = addIconToElement(self.item, self.item.remote);
+		if(addIconToElement){
+			const element = self.name[0] || self.name;
+			const path = self.item && self.item.local;
+			this.iconDisposable = addIconToElement(element, path);
+		}
 		else
 			switch (self.item.type) {
 				case 'binary':		self.name.addClass('icon-file-binary'); break;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
   "engines": {
     "atom": ">=0.204.0 <2.0.0"
   },
+  "consumedServices": {
+    "file-icons.element-icons": {
+      "versions": {
+        "1.0.0": "consumeElementIcons"
+      }
+    }
+  },
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",
     "chokidar": "^1.6.0",


### PR DESCRIPTION
[File-Icons v2](https://github.com/file-icons/atom/releases/tag/v2.0.0) uses a dynamic, regex-driven approach is used to add icons to file elements, rather than `data-name` attribute selectors. This pull request adds support for the new matching engine, so users of both packages will see icons in the remote-ftp file-view.

Fixes file-icons/atom#486.

/cc @Tms157