### PR TITLE
toggle bug fix for treeview.js for issue #652

### DIFF
--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -237,7 +237,7 @@ module.exports = TreeView = (function (parent) {
       this.panel = null;
     }
 
-    showLocalTree();
+    //showLocalTree();
   };
 
   TreeView.prototype.toggle = function () {

--- a/lib/views/tree-view.js
+++ b/lib/views/tree-view.js
@@ -236,8 +236,6 @@ module.exports = TreeView = (function (parent) {
       this.panel.destroy();
       this.panel = null;
     }
-
-    //showLocalTree();
   };
 
   TreeView.prototype.toggle = function () {


### PR DESCRIPTION
Keyboard shortcuts were not working properly. Commenting out line 240 is a quick temporary fix to restore correct toggle behaviour