### PR TITLE
Resolved bug in sync system

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -50,7 +50,8 @@ export default (function INIT() {
 
           const dir = self.getProjectPath();
 
-          const watchDataFormatted = watchData.map(watch => Path.resolve(dir, watch));
+          const watchDataFormatted = watchData.map(watch => Path.resolve(dir+watch));
+          //console.log(JSON.stringify(watchDataFormatted));
 
           const watcher = chokidar.watch(watchDataFormatted, {
             ignored: /[\/\\]\./,
@@ -60,6 +61,9 @@ export default (function INIT() {
           watcher
           .on('change', (path) => {
             self.watch.queueUpload.apply(self, [path]);
+            atom.notifications.addInfo('Remote FTP: Change detected in: '+ path, {
+              dismissable: false,
+            });
           });
 
           self.files = watchDataFormatted.slice();
@@ -583,6 +587,12 @@ export default (function INIT() {
       // search all files in rootPath recursively
       while (queue.length > 0) {
         const currentPath = queue.pop();
+
+        if (!FS.existsSync(currentPath))
+        {
+          FS.closeSync(FS.openSync(currentPath, 'w'));
+        }
+
         const filesFound = FS.readdirSync(currentPath);
 
         for (const fileName of filesFound) {
@@ -615,15 +625,40 @@ export default (function INIT() {
       if (typeof callback === 'function') callback.apply(null, [list]);
     }
 
-    syncRemoteLocal(remote, isFile, callback) {
+    syncRemoteFileToLocal(remote, callback) {
+      const self = this;
+      // verify active connection
+      if (self.status == "CONNECTED")
+      {
+        self._enqueue(() => {
+          self.connector.get(remote, false, function (err) {
+            if (err) {
+              if (typeof callback === 'function') callback.apply(null, [err]);
+                return;
+            }
+            self._next();
+          });
+        }, `Sync ${Path.basename(remote)}`);
+      } else {
+        atom.notifications.addError('Remote FTP: Not connected!', {
+          dismissable: true,
+        });
+      }
+      return self;
+    }
+
+    syncRemoteDirectoryToLocal(remote, isFile, callback) {
       // TODO: Tidy up this function. Does ( probably ) not need to list from the connector
       // if isFile === true. Will need to check to see if that doesn't break anything before
       // implementing. In the meantime current solution should work for #453
+      //
+      // TODO: This method only seems to be referenced by the context menu command so gracefully
+      // removing list without breaking this method should be do-able. 'isFile' is always sending
+      // false at the moment inside commands.js
       const self = this;
 
       if (!remote) return;
 
-      self.onceConnected(() => {
         self._enqueue(() => {
           const local = self.toLocal(remote);
 
@@ -646,7 +681,6 @@ export default (function INIT() {
                 let local;
 
                 if (!remote) return error();
-
 
                 if (remote.type === 'd') return n();
 
@@ -678,15 +712,38 @@ export default (function INIT() {
           // that already use list command. Is file is used only for ftp connector
           // as it will list a file as a file of itself unlinke with sftp which
           // will throw an error.
-        }, `Sync local ${Path.basename(remote)}`);
-      });
+        }, `Sync ${Path.basename(remote)}`);
       return self;
     }
 
-    syncLocalRemote(local, callback) {
+    syncLocalFileToRemote(local, callback) {
       const self = this;
+      // verify active connection
+      if (self.status == "CONNECTED")
+      {
+        // progress
+        self._enqueue((progress) => {
+          self.connector.put(local, function (err) {
+            if (err) {
+              if (typeof callback === 'function') callback.apply(null, [err]);
+                return;
+              }
+            self._next();
+          });
+        }, `Sync: ${Path.basename(local)}`);
+      } else {
+        atom.notifications.addError('Remote FTP: Not connected!', {
+          dismissable: true,
+        });
+      }
+      return self;
+    }
 
-      self.onceConnected(() => {
+    syncLocalDirectoryToRemote(local, callback) {
+      const self = this;
+      // verify active connection
+      if (self.status == "CONNECTED")
+      {
         self._enqueue((progress) => {
           const remote = self.toRemote(local);
 
@@ -721,8 +778,9 @@ export default (function INIT() {
                 const local = locals.shift();
                 let remote;
 
-                if (!local) return error();
-
+                if (!local) {
+                  return error();
+                }
                 if (local.type === 'd') return n();
 
                 const toRemote = self.toRemote(local.name);
@@ -745,9 +803,12 @@ export default (function INIT() {
               n();
             });
           });
-        }, `Sync remote ${Path.basename(local)}`);
-      });
-
+        }, `Sync ${Path.basename(local)}`);
+      } else {
+        atom.notifications.addError('Remote FTP: Not connected!', {
+          dismissable: true,
+        });
+      }
       return self;
     }
 

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -483,13 +483,52 @@ const init = function INIT() {
       enabled: true,
       command() {
         const remotes = remoteftp.treeView.getSelected();
-
         remotes.forEach((view) => {
           if (!view) return;
-          const isFile = view.item instanceof File;
-          client.syncRemoteLocal(view.item.remote, isFile, () => {
 
-          });
+          const target = view.children().attr('data-path');
+
+          // checking to see if we're working with a file
+          if (view.item.constructor.name == 'File') {
+            try {
+              client.syncRemoteFileToLocal(view.item.remote);
+            }
+            catch (err) {
+              // syncRemoteFileToLocal() is not setup to return any errors here,
+              // as they are handled else where. TODO: perhaps look into a way to restructure
+              // sequence to handle all errors in one location (here)
+              atom.notifications.addError('Remote FTP: Error Syncing "'+ Path.basename(view.item.remote) +'" to local', {
+                dismissable: true
+              });
+            }
+            finally {
+              // TODO: Verify transfer was completed successfully by checking files
+              // and verifying sizes or hash of both files
+              atom.notifications.addInfo('Remote FTP: Synced "'+ Path.basename(view.item.remote) +'" to local!', {
+                dismissable: true
+              });
+            }
+          } else { // process sync for entire directory
+            var isFile = false;
+            try {
+              client.syncRemoteDirectoryToLocal(view.item.remote, this.isFile);
+            }
+            catch (err) {
+              // syncRemoteDirectoryToLocal() is not setup to return any errors here,
+              // as they are handled else where. TODO: perhaps look into a way to restructure
+              // sequence to handle all errors in one location (here)
+              atom.notifications.addError('Remote FTP: Error in Syncing "'+ Path.basename(view.item.remote) +'" to local', {
+                dismissable: true
+              });
+            }
+            finally {
+              // TODO: Verify transfer was completed successfully by checking files
+              // and verifying sizes or hash of both files
+              atom.notifications.addInfo('Remote FTP: Synced "'+ Path.basename(view.item.remote) +'" to local!!', {
+                dismissable: true
+              });
+            }
+          }
         });
       },
     },
@@ -508,16 +547,54 @@ const init = function INIT() {
         locals.forEach((local) => {
           if (!local) return;
 
-          client.syncLocalRemote(local, () => {
-            const remote = client.toRemote(local);
-            if (remote) {
-              let parent = remoteftp.treeView.resolve(remote);
-              if (parent && !(parent.item instanceof Directory)) {
-                parent = remoteftp.treeView.resolve(Path.dirname(remote).replace(/\\/g, '/'));
-              }
-              if (parent) parent.open();
+          const remote = client.toRemote(local);
+
+          // checking to see if we're working with a file
+          if (FS.isFileSync(local) == true) {
+            try {
+              client.syncLocalFileToRemote(local);
             }
-          });
+            catch (err) {
+              // syncLocalFileToRemote() is not setup to return any errors here,
+              // as they are handled else where. TODO: perhaps look into a way to restructure
+              // sequence to handle all errors in one location (here)
+              atom.notifications.addError('Remote FTP: Error Syncing "'+ Path.basename(local) +'" to remote', {
+                dismissable: true
+              });
+            }
+            finally {
+              // TODO: Verify transfer was completed successfully by checking remote
+              // and verifying sizes or hash of both files
+              atom.notifications.addInfo('Remote FTP: Synced "'+ Path.basename(local) +'" to remote', {
+                dismissable: true
+              });
+            }
+
+          } else { // process sync for entire directory
+
+            try {
+              client.syncLocalDirectoryToRemote(local, () => {
+                atom.notifications.addInfo('Remote FTP: Synced "'+ local +'" to remote', {
+                  dismissable: true
+                });
+              });
+            }
+            catch (err) {
+              // syncLocalDirectoryToRemote() is not setup to return any errors here,
+              // as they are handled else where. TODO: perhaps look into a way to restructure
+              // sequence to handle all errors in one location (here)
+              atom.notifications.addError('Remote FTP: Error Syncing "'+ local +'" to remote', {
+                dismissable: true
+              });
+            }
+            finally {
+              // TODO: Verify transfer was completed successfully by checking remote
+              // and verifying sizes or hash of both files
+              atom.notifications.addInfo('Remote FTP: Synced "'+ local +'" to remote', {
+                dismissable: true
+              });
+            }
+          }
         });
       },
     },

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -574,6 +574,8 @@ const init = function INIT() {
 
             try {
               client.syncLocalDirectoryToRemote(local, () => {
+                // TODO: Verify transfer was completed successfully by checking remote
+                // and verifying sizes or hash of both files
                 atom.notifications.addInfo('Remote FTP: Synced "'+ local +'" to remote', {
                   dismissable: true
                 });
@@ -588,11 +590,7 @@ const init = function INIT() {
               });
             }
             finally {
-              // TODO: Verify transfer was completed successfully by checking remote
-              // and verifying sizes or hash of both files
-              atom.notifications.addInfo('Remote FTP: Synced "'+ local +'" to remote', {
-                dismissable: true
-              });
+              
             }
           }
         });


### PR DESCRIPTION
Manual sync from context menu was not working. There is at least a half
dozen issues about this problem in Issues: #695 #694 #692 #691 #689 #688 #699 

What I did in **client.js** was broke up the four actions into separate
methods and tested and verified each worked as expected.

```
syncRemoteFileToLocal()
syncRemoteDirectoryToLocal()
syncLocalFileToRemote()
syncLocalDirectoryToRemote()
```

Also made changes to **commands.js** to handle the new methods and I also
implemented a try/catch/finally sequence. It has room for improvement
(like file verification) but it works for now to resolve the bug for
everyone.

Also added Atom notifications once each action is complete for some
visual feedback.