### PR TITLE
Fix JSON config file not reporting errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -190,6 +190,7 @@ export default (function INIT() {
       } catch (error) {
         // try to extract bad syntax location from error message
         let lineNumber = -1;
+        let index;
         const regex = /at position ([0-9]+)$/;
         const result = error.message.match(regex);
         if (result && result.length > 0) {


### PR DESCRIPTION
The variable `index` was not defined and so was silently failing in console

This happened when an error occurred in the FTP config file and the JSON could not parse the file correctly