### PR TITLE
remoteCommand and remoteShell

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -394,6 +394,8 @@ export default (function INIT() {
           };
 
           info.filePermissions = self.info.filePermissions;
+          info.remoteCommand = self.info.remoteCommand;
+          info.remoteShell = self.info.remoteShell;
           if (self.info.keyboardInteractive) info.tryKeyboard = true;
 
           self.connector = new SFTP(self);

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -46,6 +46,29 @@ export default (() => {
             return;
           }
 
+          if (self.info.remoteShell) {
+            self.emit('opening shell', self.info.remoteShell);
+            self.ssh2.shell((err, stream) => {
+              if (err) {
+                self.emit('error', err);
+                self.disconnect();
+                return;
+              }
+              stream.end(self.info.remoteShell + '\nexit\n');
+            });
+          }
+
+          if (self.info.remoteCommand) {
+            self.emit('executing command', self.info.remoteCommand);
+            self.ssh2.exec(self.info.remoteCommand, (err, stream) => {
+              if (err) {
+                self.emit('error', err);
+                self.disconnect();
+                return;
+              }
+            });
+          }
+
           self.status = 'connected';
 
           self.sftp = sftp;

--- a/lib/connectors/sftp.js
+++ b/lib/connectors/sftp.js
@@ -47,7 +47,7 @@ export default (() => {
           }
 
           if (self.info.remoteShell) {
-            self.emit('opening shell', self.info.remoteShell);
+            self.emit('openingShell', self.info.remoteShell);
             self.ssh2.shell((err, stream) => {
               if (err) {
                 self.emit('error', err);
@@ -59,7 +59,7 @@ export default (() => {
           }
 
           if (self.info.remoteCommand) {
-            self.emit('executing command', self.info.remoteCommand);
+            self.emit('executingCommand', self.info.remoteCommand);
             self.ssh2.exec(self.info.remoteCommand, (err, stream) => {
               if (err) {
                 self.emit('error', err);

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -102,6 +102,8 @@ const init = function INIT() {
           connTimeout: 10000,
           keepalive: 10000,
           keyboardInteractive: false,
+          remoteCommand: '',
+          remoteShell: '',
           watch: [],
           watchTimeout: 500,
         });


### PR DESCRIPTION
Hi Michael, I started work on issue #495. Executing a remote command seems to work with simple commands like "touch /tmp/testfile". However it is not sufficient for "sudo su - someuser". This command simply has no effect. The files are still being transferred under the user that is used for the login. That's why I started to take a look on executing a remote shell. The current implementation opens an interactive shell when connecting, a stream object is returned and then I execute:
```
stream.end(self.info.remoteShell + '\nexit\n');
```
Again this has no effect on the file transfer. I guess the shell must stay open and all file transfer should be done via the stream object. But that seems to become a big change.