### PR TITLE
Support for loading SSH config from a file

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@ import FTP from './connectors/ftp';
 import SFTP from './connectors/sftp';
 import PromptPassDialog from './dialogs/prompt-pass-dialog';
 import Ignore from 'ignore';
+import sshConfig from 'ssh-config'
 
 const atom = global.atom;
 
@@ -141,7 +142,36 @@ export default (function INIT() {
           }
         }
         if (json !== null && typeof callback === 'function') {
-          callback.apply(self, [err, json]);
+          let configPath = atom.config.get('Remote-FTP.sshConfigPath')
+
+          if (configPath) {
+            FS.readFile(configPath, 'utf8', (err, conf) => {
+              if (err) return error(err);
+
+              let config = sshConfig.parse(conf);
+
+              let section = config.find({
+                Host: self.info.host
+              });
+
+              if(section !== null) {
+                let mapping = new Map([
+                  ['HostName', 'host'],
+                  ['Port', 'port'],
+                  ['User', 'user'],
+                  ['IdentityFile', 'privatekey'],
+                  ['ServerAliveInterval', 'keepalive'],
+                  ['ConnectTimeout', 'connTimeout']
+                ]);
+
+                section.config.forEach(line => self.info[mapping.get(line.param)] = line.value);
+              }
+
+              callback.apply(self, [err, self.info]);
+            });
+          } else {
+            callback.apply(self, [err, json]);
+          }
         }
       });
     }

--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -27,5 +27,10 @@
   "enableTransferNotifications":{
     "type":"boolean",
     "default":false
+  },
+  "sshConfigPath": {
+    "type": "string",
+    "default": "",
+    "description": "Absolute path to your SSH config file (eg. /Users/yourname/.ssh/config). Optional."
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "ignore": "^3.2.0",
     "ssh2": "^0.5.4",
     "strip-json-comments": "^2.0.1",
-    "theorist": "^1.0.2"
+    "theorist": "^1.0.2",
+    "ssh-config": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^3.7.1",


### PR DESCRIPTION
Adds new optional config item to specify the path for the system SSH config file. If specified, the file is searched for a matching host and its details are then used for the connection.

Example .ftpconfig:
```json
{
  "protocol": "sftp",
  "host": "test"
}
```

Example SSH config:
```
Host test
  HostName ssh.example.com
  Port 22
  User youruser
  IdentityFile /Users/youruser/.ssh/id_rsa
```

This should resolve #301 but I only tested it with my own very simple config.