### PR TITLE
Removed arrow function, we need the 'this' to be intact

### DIFF
--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -388,7 +388,7 @@ const init = () => {
         let successfulTransfers = 0;
         let attemptedTransfers = 0;
 
-        $treeSelected.each(() => {
+        $treeSelected.each( function() {
           const path = this.getPath ? this.getPath() : '';
           const localPath = path.replace(client.root.local, '');
 


### PR DESCRIPTION
Using arrow function means that 'this' on next line is not properly defined, resulting in an empty path to the selected file. On my machine this meant:

- remote path was set to the root of the site
- the desired file was not downloaded
- many empty directories were created locally (matching remote)
