### PR TITLE
#972 reload .ftpignore on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+## Fixed
++ Fix .ftpignore from being loaded " [#972](https://github.com/icetee/remote-ftp/issues/972)
 
 ## [2.1.0] - 2017-12-06 🎅🏻
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -353,7 +353,8 @@ export default class Client {
     const self = this;
     let haseIgnore = true;
 
-    if (!self.ignoreFilter) {
+    // updateIgnore when not set or .ftpignore is saved
+    if (!self.ignoreFilter || (local === self.getFilePath(self.ignoreBaseName))) {
       haseIgnore = self.updateIgnore();
     }
 


### PR DESCRIPTION
Fixes: .ftpignore doesn't work when I ignore folder #972

The .ftpignore file is only loaded on atom start; this change allows the .ftpignore file to be reloaded when the file is changed.