### PR TITLE
Add suggestion to create .ftpignore file for security purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ FTP/FTPS/SFTP client for Atom.io
 4. Once connected you should be seeing the content of the remote connection
 5. **All** basic **commands** (`connect`, `disconnect`, ...) are **available from** the **sidebar context menu** and the Command Palette
 
+Tip: **Create an ignore file** to prevent your sensitive information from getting synced to your host (Packages -> Remote FTP -> Create ignore file)
+
 ## Keyboard shortcuts
 
 We all know that some handy commands can make our daily task easier, this are meant to do that, be aware that the action of any of them could overwrite or be over written by any other plugin.


### PR DESCRIPTION
Why this suggestion?

Sometimes in the past, visitors could access my FTP login details from www.example.com/.ftpconfig . 

This can be resolved by creating an ignore file. Just reminding the users about the same.